### PR TITLE
Bug Fix: #3392

### DIFF
--- a/src/fullpage.js
+++ b/src/fullpage.js
@@ -349,9 +349,10 @@
                 if(value){
                     setMouseWheelScrolling(true);
                     addTouchHandler();
-                }else{
-                    setMouseWheelScrolling(false);
-                    removeTouchHandler();
+                }else if(
+                !options.scrollBar && options.autoScrolling) {
+                      setMouseWheelScrolling(false);
+                      removeTouchHandler();
                 }
             }
         }


### PR DESCRIPTION
setAllowScrolling: false does not work with scrollBar:true.

Added else if update to ensure scrolling stopped when appropriate.

1- Make sure to commit it to the `dev` branch!
2- Read https://github.com/alvarotrigo/fullPage.js/wiki/Contributing-to-fullpage.js